### PR TITLE
feat: enforce minimum replicas for compute.googleapis.com/Autoscaler

### DIFF
--- a/policies/templates/gcp_compute_autoscaler_replicas.yaml
+++ b/policies/templates/gcp_compute_autoscaler_replicas.yaml
@@ -85,6 +85,6 @@ spec:
           minimum_replicas_meets_policy := {resource_minimum_replicas >= minimum_replicas}
 
         	message := sprintf("%v does not meet the minimum replicas.", [asset.name])
-        	metadata := {"zone": asset_zone}
+        	metadata := {"minimum_replicas": resource_minimum_replicas}
         }
         #ENDINLINE

--- a/policies/templates/gcp_compute_autoscaler_replicas.yaml
+++ b/policies/templates/gcp_compute_autoscaler_replicas.yaml
@@ -84,7 +84,7 @@ spec:
           resource_minimum_replicas := asset.resource.data.autoscalingPolicy.minNumReplicas
           minimum_replicas_meets_policy := {resource_minimum_replicas >= minimum_replicas}
 
-        	message := sprintf("%v is in a disallowed zone.", [asset.name])
+        	message := sprintf("%v does not meet the minimum replicas.", [asset.name])
         	metadata := {"zone": asset_zone}
         }
         #ENDINLINE

--- a/policies/templates/gcp_compute_autoscaler_replicas.yaml
+++ b/policies/templates/gcp_compute_autoscaler_replicas.yaml
@@ -80,7 +80,7 @@ spec:
         	count(matches) == 0
 
           # Check that autoscaling policy has the minimum replicas
-          minimum_replicas := 2 # TODO: Replace as input
+          minimum_replicas := lib.get_default(params, "minimum_replicas", "0")
           resource_minimum_replicas := asset.resource.data.autoscalingPolicy.minNumReplicas
           minimum_replicas_meets_policy := {resource_minimum_replicas >= minimum_replicas}
 

--- a/policies/templates/gcp_compute_autoscaler_replicas.yaml
+++ b/policies/templates/gcp_compute_autoscaler_replicas.yaml
@@ -13,20 +13,17 @@
 # limitations under the License.
 #
 
-# This template is for policies restricting the locations
-# of compute (VM instance / persistent disk) resources to
-# specific zones in GCP. It supports allowlist or denylist
-# modes, as well as exempting selected assets from the list.
+# TODO: Update definition
 
 apiVersion: templates.gatekeeper.sh/v1alpha1
 kind: ConstraintTemplate
 metadata:
-  name: gcp-compute-single-instance-v1
+  name: gcp-compute-autoscaler-replicas-v1
 spec:
   crd:
     spec:
       names:
-        kind: GCPComputeSingleInstanceConstraintV1
+        kind: GCPComputeAutoscalerReplicasConstraintV1
       validation:
         openAPIV3Schema:
           properties:
@@ -34,7 +31,7 @@ spec:
               type: array
               items:
                 type: string
-              description: "Array of compute assets to exempt from single instance restriction.
+              description: "Array of compute assets to exempt from the defined autoscaler replicas constraint.
                 String values in the array should correspond to the full name values
                 of exempted devices."
   targets:
@@ -56,54 +53,38 @@ spec:
         # limitations under the License.
         #
 
-        # TODO
-
-        package templates.gcp.GCPComputeZoneConstraintV1
+        package templates.gcp.GCPComputeAutoscalerReplicasConstraintV1
 
         import data.validator.gcp.lib as lib
 
-        #####################################
-        # Find Compute Asset Zone Violations
-        #####################################
+        ####################################################
+        # Find Compute Autoscaler Minimum Replicas Violation
+        ####################################################
+
         deny[{
+          # A deny rule will raise a violation if the block below evaluates to true
         	"msg": message,
         	"details": metadata,
         }] {
+          # Rego logic: This block evaluates to true if all lines evaluate to true
         	constraint := input.constraint
         	lib.get_constraint_params(constraint, params)
 
-        	# Verify that resource is Instance or Disk
+        	# Verify that resource is an Autoscaler
         	asset := input.asset
-        	{asset.asset_type} == {asset.asset_type} & {"compute.googleapis.com/Instance", "compute.googleapis.com/Disk"}
+        	{asset.asset_type} == {asset.asset_type} & {"compute.googleapis.com/Autoscaler"}
 
         	# Check if resource is in exempt list
         	exempt_list := params.exemptions
         	matches := {asset.name} & cast_set(exempt_list)
         	count(matches) == 0
 
-        	# Check that zone is in allowlist/denylist
-        	target_zones := params.zones
-        	asset_zone_tokens := split(asset.resource.data.zone, "/")
-        	asset_zone := asset_zone_tokens[minus(count(asset_zone_tokens), 1)]
-        	zone_matches := {asset_zone} & cast_set(target_zones)
-        	target_zone_match_count(params.mode, desired_count)
-        	count(zone_matches) == desired_count
+          # Check that autoscaling policy has the minimum replicas
+          minimum_replicas := 2 # TODO: Replace as input
+          resource_minimum_replicas := asset.resource.data.autoscalingPolicy.minNumReplicas
+          minimum_replicas_meets_policy := {resource_minimum_replicas >= minimum_replicas}
 
         	message := sprintf("%v is in a disallowed zone.", [asset.name])
         	metadata := {"zone": asset_zone}
-        }
-
-        #################
-        # Rule Utilities
-        #################
-
-        # Determine the overlap between zones under test and constraint
-        # By default (allowlist), we violate if there isn't overlap
-        target_zone_match_count(mode) = 0 {
-        	mode != "denylist"
-        }
-
-        target_zone_match_count(mode) = 1 {
-        	mode == "denylist"
         }
         #ENDINLINE

--- a/policies/templates/gcp_compute_single_instance.yaml
+++ b/policies/templates/gcp_compute_single_instance.yaml
@@ -1,0 +1,109 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This template is for policies restricting the locations
+# of compute (VM instance / persistent disk) resources to
+# specific zones in GCP. It supports allowlist or denylist
+# modes, as well as exempting selected assets from the list.
+
+apiVersion: templates.gatekeeper.sh/v1alpha1
+kind: ConstraintTemplate
+metadata:
+  name: gcp-compute-single-instance-v1
+spec:
+  crd:
+    spec:
+      names:
+        kind: GCPComputeSingleInstanceConstraintV1
+      validation:
+        openAPIV3Schema:
+          properties:
+            exemptions:
+              type: array
+              items:
+                type: string
+              description: "Array of compute assets to exempt from single instance restriction.
+                String values in the array should correspond to the full name values
+                of exempted devices."
+  targets:
+    validation.gcp.forsetisecurity.org:
+      rego: |
+        #
+        # Copyright 2021 Google LLC
+        #
+        # Licensed under the Apache License, Version 2.0 (the "License");
+        # you may not use this file except in compliance with the License.
+        # You may obtain a copy of the License at
+        #
+        #     https://www.apache.org/licenses/LICENSE-2.0
+        #
+        # Unless required by applicable law or agreed to in writing, software
+        # distributed under the License is distributed on an "AS IS" BASIS,
+        # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        # See the License for the specific language governing permissions and
+        # limitations under the License.
+        #
+
+        # TODO
+
+        package templates.gcp.GCPComputeZoneConstraintV1
+
+        import data.validator.gcp.lib as lib
+
+        #####################################
+        # Find Compute Asset Zone Violations
+        #####################################
+        deny[{
+        	"msg": message,
+        	"details": metadata,
+        }] {
+        	constraint := input.constraint
+        	lib.get_constraint_params(constraint, params)
+
+        	# Verify that resource is Instance or Disk
+        	asset := input.asset
+        	{asset.asset_type} == {asset.asset_type} & {"compute.googleapis.com/Instance", "compute.googleapis.com/Disk"}
+
+        	# Check if resource is in exempt list
+        	exempt_list := params.exemptions
+        	matches := {asset.name} & cast_set(exempt_list)
+        	count(matches) == 0
+
+        	# Check that zone is in allowlist/denylist
+        	target_zones := params.zones
+        	asset_zone_tokens := split(asset.resource.data.zone, "/")
+        	asset_zone := asset_zone_tokens[minus(count(asset_zone_tokens), 1)]
+        	zone_matches := {asset_zone} & cast_set(target_zones)
+        	target_zone_match_count(params.mode, desired_count)
+        	count(zone_matches) == desired_count
+
+        	message := sprintf("%v is in a disallowed zone.", [asset.name])
+        	metadata := {"zone": asset_zone}
+        }
+
+        #################
+        # Rule Utilities
+        #################
+
+        # Determine the overlap between zones under test and constraint
+        # By default (allowlist), we violate if there isn't overlap
+        target_zone_match_count(mode) = 0 {
+        	mode != "denylist"
+        }
+
+        target_zone_match_count(mode) = 1 {
+        	mode == "denylist"
+        }
+        #ENDINLINE


### PR DESCRIPTION
In this PR,

- added `GCPComputeAutoscalerReplicasConstraintV1` template to enforce minimum replicas for `compute.googleapis.com/Autoscaler`
- added constraint to use `GCPComputeAutoscalerReplicasConstraintV1`

Note to self: Having a template does not mean the constraint will be evaluated. It will NOT be evaluated unless it's used as a constraint and placed in the appropriate `constraints` folder.